### PR TITLE
updated URI for `vet`

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -25,4 +25,4 @@ To build the micro cli:
 
 Install tools used by the test suite:
 
-- `bin/go get code.google.com/p/go.tools/cmd/vet`
+- `bin/go get golang.org/x/tools/cmd/vet`


### PR DESCRIPTION
Fixes error:

can't load package: the code.google.com/p/go.tools/cmd/vet command has moved; use golang.org/x/tools/cmd/vet instead.