### PR TITLE
Fix an issue with closures in gccgo.

### DIFF
--- a/deployment/agentclient/http/agent_client.go
+++ b/deployment/agentclient/http/agent_client.go
@@ -152,7 +152,8 @@ func (c *agentClient) sendAsyncTaskMessage(method string, arguments []interface{
 	})
 
 	getTaskRetryStrategy := boshretry.NewUnlimitedRetryStrategy(c.getTaskDelay, getTaskRetryable, c.logger)
-	return value, getTaskRetryStrategy.Try()
+	err = getTaskRetryStrategy.Try()
+	return value, err
 }
 
 func (c *agentClient) CompilePackage(packageSource biagentclient.BlobRef, compiledPackageDependencies []biagentclient.BlobRef) (compiledPackageRef biagentclient.BlobRef, err error) {

--- a/deployment/agentclient/http/agent_client.go
+++ b/deployment/agentclient/http/agent_client.go
@@ -152,6 +152,8 @@ func (c *agentClient) sendAsyncTaskMessage(method string, arguments []interface{
 	})
 
 	getTaskRetryStrategy := boshretry.NewUnlimitedRetryStrategy(c.getTaskDelay, getTaskRetryable, c.logger)
+	// cannot call getTaskRetryStrategy.Try in the return statement due to gccgo
+	// execution order issues: https://code.google.com/p/go/issues/detail?id=8698&thanks=8698&ts=1410376474
 	err = getTaskRetryStrategy.Try()
 	return value, err
 }


### PR DESCRIPTION
GCC Go frontend has a bug that caused an error from https://github.com/cloudfoundry/bosh-init/issues/34 ([bug description](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66431)). 

This PR allows you to run bosh-init deployment with this bug.
