### PR TITLE
Avoid running erb-renderer with ruby 1.9.3.

### DIFF
--- a/templatescompiler/erbrenderer/template_evaluation_context_rb.go
+++ b/templatescompiler/erbrenderer/template_evaluation_context_rb.go
@@ -8,6 +8,8 @@ require "json"
 require "erb"
 require "yaml"
 
+raise "You should use Ruby with version 2.0 or greater" if RUBY_VERSION.match(/1\.\d\.\d/)
+
 class Hash
   def recursive_merge!(other)
     self.merge!(other) do |_, old_value, new_value|


### PR DESCRIPTION
Hi, all.

Here is a problem that I've met several times. First time I say it yesterday, when I tried to help in IRC channel ([link to the discussion](https://botbot.me/freenode/bosh/2015-09-22/?msg=50303516&page=2)). The problem was that running `bosh-init` failed and produced the following output:
```
Command 'deploy' failed:
  Deploying:
    Building state for instance 'bosh/0':
      Rendering job templates for instance 'bosh/0':
        Rendering templates for job 'director/06a47e4bffdad38c76c6f1069d1f477635800a5e':
          Rendering template src: director.yml.erb.erb, dst: config/director.yml.erb:
            Rendering template src: /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/bosh-init-release261922766/extracted_jobs/director/templates/director.yml.erb.erb, dst: /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/rendered-jobs773245294/config/director.yml.erb:
              Running ruby to render templates:
                Running command: 'ruby /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/erb-renderer551137540/erb-render.rb /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/erb-renderer551137540/erb-context.json /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/bosh-init-release261922766/extracted_jobs/director/templates/director.yml.erb.erb /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/rendered-jobs773245294/config/director.yml.erb', stdout: '', stderr: '/home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/erb-renderer551137540/erb-render.rb:180:in `rescue in render': Error filling in template '/home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/bosh-init-release261922766/extracted_jobs/director/templates/director.yml.erb.erb' for director/0 (line 134: #<JSON::GeneratorError: only generation of JSON objects or arrays allowed>) (RuntimeError)
        from /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/erb-renderer551137540/erb-render.rb:166:in `render'
        from /home/ubuntu/.bosh_init/installations/a0c38fbf-18e2-4bb8-4ccd-d16a2e4860ca/tmp/erb-renderer551137540/erb-render.rb:191:in `<main>'
':
```
Taking a closer look on this problem I found out that it happens because bosh-init uses host version of Ruby. And different versions of ruby have different behaviour for `YAML.dump` method, that is called in templates of BOSH release in several places ([here for example](https://github.com/cloudfoundry/bosh/blob/4c6eed626d3242c0e6b24fca08e6d1b4db9d7f10/release/jobs/director/templates/director.yml.erb.erb#L134-L136)). 

In Ruby 2.0+ you can run `YAML.dump` on strings and booleans without any problems:
```
2.1.5 :001 > require 'json'
 => true
2.1.5 :002 > JSON.dump(false)
 => "false"
```

Still in case of Ruby 1.9.3 an exception is raised because `JSON.dump` expects an array or hash as a parameter:
```
1.9.3-p551 :001 > require 'json'
 => true
1.9.3-p551 :002 > JSON.dump(false)
JSON::GeneratorError: only generation of JSON objects or arrays allowed
	from /Users/allomov/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/json/common.rb:216:in `generate'
	from /Users/allomov/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/json/common.rb:216:in `generate'
	from /Users/allomov/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/json/common.rb:352:in `dump'
	from (irb):2
	from /Users/allomov/.rvm/rubies/ruby-1.9.3-p551/bin/irb:12:in `<main>'
```

The message that people see in the current stacktrace does not reflects an actual root of the problem. So I decided to place an exception with according message in case when ruby version is wrong. As far as I can see this is the easiest way to cope with this issue.

This issue is aggravated by the fact that standard Ubuntu goes with Ruby 1.9.3 pre-installed and new comers can easily face it.