### PR TITLE
Fix parsing of YAML files with non-specific node tags

### DIFF
--- a/internal/gopkg.in/yaml.v2/decode_test.go
+++ b/internal/gopkg.in/yaml.v2/decode_test.go
@@ -403,6 +403,12 @@ var unmarshalTests = []struct {
 	}, {
 		"%TAG !y! tag:yaml.org,2002:\n---\nv: !y!int '1'",
 		map[string]interface{}{"v": 1},
+	}, {
+		"v: ! 12",
+		map[string]interface{}{"v": "12"},
+	}, {
+		"seq: ! [A, B]",
+		map[string]interface{}{"seq": []interface{}{"A", "B"}},
 	},
 
 	// Anchors and aliases.

--- a/internal/gopkg.in/yaml.v2/scannerc.go
+++ b/internal/gopkg.in/yaml.v2/scannerc.go
@@ -2002,12 +2002,6 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 		}
 	}
 
-	// Check if the tag is non-empty.
-	if len(s) == 0 {
-		yaml_parser_set_scanner_tag_error(parser, directive,
-			start_mark, "did not find expected tag URI")
-		return false
-	}
 	*uri = s
 	return true
 }


### PR DESCRIPTION
It enable go-yaml to parse YAML files with non-specific tag `!`. Also
unit test was added for this case to make sure we use the right version
of go-yaml.
Separate pull request was sent to go-yaml
https://github.com/go-yaml/yaml/pull/133/commits

[#104962208] (https://www.pivotaltracker.com/story/show/104962208)

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>