### PR TITLE
Backwards compatible BOSH 2.0 releases deploy.

### DIFF
--- a/templatescompiler/erbrenderer/template_evaluation_context_rb.go
+++ b/templatescompiler/erbrenderer/template_evaluation_context_rb.go
@@ -2,7 +2,6 @@ package erbrenderer
 
 const templateEvaluationContextRb = `
 # Based on common/properties/template_evaluation_context.rb
-require "rubygems"
 require "ostruct"
 require "json"
 require "erb"
@@ -66,6 +65,10 @@ class TemplateEvaluationContext
 
     yield *values
     InactiveElseBlock.new
+  end
+  
+  def if_link(name)
+    false
   end
 
   private

--- a/templatescompiler/erbrenderer/template_evaluation_context_rb.go
+++ b/templatescompiler/erbrenderer/template_evaluation_context_rb.go
@@ -2,6 +2,7 @@ package erbrenderer
 
 const templateEvaluationContextRb = `
 # Based on common/properties/template_evaluation_context.rb
+require "rubygems"
 require "ostruct"
 require "json"
 require "erb"


### PR DESCRIPTION
Releases which use `if_link` and fallback to using properties will successfully deploy as `if_link` has been hardcoded to return false.

Also removes unnecessary "rubygems" requirement.

Signed-off-by: Caleb Miles <cmiles@pivotal.io>