### PR TITLE
Add extra validations to bosh-init manifest: cloud_provider.mbus and cloud_provider.agent.mbus properties should user https protocol and have the same creds and ports

### DIFF
--- a/installation/manifest/validator.go
+++ b/installation/manifest/validator.go
@@ -1,10 +1,13 @@
 package manifest
 
 import (
+	"net"
+	"net/url"
 	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-init/internal/github.com/cloudfoundry/bosh-utils/errors"
 	boshlog "github.com/cloudfoundry/bosh-init/internal/github.com/cloudfoundry/bosh-utils/logger"
+	biproperty "github.com/cloudfoundry/bosh-init/internal/github.com/cloudfoundry/bosh-utils/property"
 	birelsetmanifest "github.com/cloudfoundry/bosh-init/release/set/manifest"
 )
 
@@ -38,6 +41,68 @@ func (v *validator) Validate(manifest Manifest, releaseSetManifest birelsetmanif
 	_, found := releaseSetManifest.FindByName(cpiReleaseName)
 	if !found {
 		errs = append(errs, bosherr.Errorf("cloud_provider.template.release '%s' must refer to a release in releases", cpiReleaseName))
+	}
+
+	mbusURLString := manifest.Mbus
+	if v.isBlank(mbusURLString) {
+		errs = append(errs, bosherr.Error("cloud_provider.mbus must be provided"))
+	}
+
+	agentProperties, found := manifest.Properties["agent"]
+	if !found {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent must be specified"))
+	}
+
+	agentPropertiesMap, ok := agentProperties.(biproperty.Map)
+	if !ok {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent must be a hash"))
+	}
+
+	agentMbusURLProperty, found := agentPropertiesMap["mbus"]
+	if !found {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus must be specified"))
+	}
+
+	agentMbusURLString, ok := agentMbusURLProperty.(string)
+	if !ok {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus should be string"))
+	}
+
+	if !v.isBlank(mbusURLString) && !v.isBlank(agentMbusURLString) {
+		mbusURL, mbusURLParseErr := url.ParseRequestURI(mbusURLString)
+		if mbusURLParseErr != nil {
+			errs = append(errs, bosherr.Error("cloud_provider.mbus should be a valid URL"))
+		}
+
+		agentMbusURL, agentMbusURLParseErr := url.ParseRequestURI(agentMbusURLString)
+		if agentMbusURLParseErr != nil {
+			errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus should be a valid URL"))
+		}
+
+		if (agentMbusURLParseErr == nil) && (mbusURLParseErr == nil) {
+			if mbusURL.Scheme != "https" {
+				errs = append(errs, bosherr.Error("cloud_provider.mbus must use https protocol"))
+			}
+
+			if agentMbusURL.Scheme != "https" {
+				errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus must use https protocol"))
+			}
+
+			if (mbusURL.User != nil) && (agentMbusURL.User != nil) {
+				mbusCredsAreEqual := (agentMbusURL.User.String() == mbusURL.User.String())
+				if !mbusCredsAreEqual {
+					errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same password and username"))
+				}
+			}
+
+			_, mbusPort, _ := net.SplitHostPort(mbusURL.Host)
+			_, agentMbusPort, _ := net.SplitHostPort(agentMbusURL.Host)
+			if mbusPort != agentMbusPort {
+				errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same ports"))
+			}
+
+		}
+
 	}
 
 	if len(errs) > 0 {

--- a/installation/manifest/validator.go
+++ b/installation/manifest/validator.go
@@ -43,66 +43,9 @@ func (v *validator) Validate(manifest Manifest, releaseSetManifest birelsetmanif
 		errs = append(errs, bosherr.Errorf("cloud_provider.template.release '%s' must refer to a release in releases", cpiReleaseName))
 	}
 
-	mbusURLString := manifest.Mbus
-	if v.isBlank(mbusURLString) {
-		errs = append(errs, bosherr.Error("cloud_provider.mbus must be provided"))
-	}
-
-	agentProperties, found := manifest.Properties["agent"]
-	if !found {
-		errs = append(errs, bosherr.Error("cloud_provider.properties.agent must be specified"))
-	}
-
-	agentPropertiesMap, ok := agentProperties.(biproperty.Map)
-	if !ok {
-		errs = append(errs, bosherr.Error("cloud_provider.properties.agent must be a hash"))
-	}
-
-	agentMbusURLProperty, found := agentPropertiesMap["mbus"]
-	if !found {
-		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus must be specified"))
-	}
-
-	agentMbusURLString, ok := agentMbusURLProperty.(string)
-	if !ok {
-		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus should be string"))
-	}
-
-	if !v.isBlank(mbusURLString) && !v.isBlank(agentMbusURLString) {
-		mbusURL, mbusURLParseErr := url.ParseRequestURI(mbusURLString)
-		if mbusURLParseErr != nil {
-			errs = append(errs, bosherr.Error("cloud_provider.mbus should be a valid URL"))
-		}
-
-		agentMbusURL, agentMbusURLParseErr := url.ParseRequestURI(agentMbusURLString)
-		if agentMbusURLParseErr != nil {
-			errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus should be a valid URL"))
-		}
-
-		if (agentMbusURLParseErr == nil) && (mbusURLParseErr == nil) {
-			if mbusURL.Scheme != "https" {
-				errs = append(errs, bosherr.Error("cloud_provider.mbus must use https protocol"))
-			}
-
-			if agentMbusURL.Scheme != "https" {
-				errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus must use https protocol"))
-			}
-
-			if (mbusURL.User != nil) && (agentMbusURL.User != nil) {
-				mbusCredsAreEqual := (agentMbusURL.User.String() == mbusURL.User.String())
-				if !mbusCredsAreEqual {
-					errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same password and username"))
-				}
-			}
-
-			_, mbusPort, _ := net.SplitHostPort(mbusURL.Host)
-			_, agentMbusPort, _ := net.SplitHostPort(agentMbusURL.Host)
-			if mbusPort != agentMbusPort {
-				errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same ports"))
-			}
-
-		}
-
+	err := v.validateMbusConfig(manifest)
+	if err != nil {
+		errs = append(errs, bosherr.WrapError(err, "Validating mbus cloud provider properties"))
 	}
 
 	if len(errs) > 0 {
@@ -114,4 +57,82 @@ func (v *validator) Validate(manifest Manifest, releaseSetManifest birelsetmanif
 
 func (v *validator) isBlank(str string) bool {
 	return str == "" || strings.TrimSpace(str) == ""
+}
+
+func (v *validator) validateMbusConfig(manifest Manifest) error {
+	errs := []error{}
+
+	mbusURLString := manifest.Mbus
+	if v.isBlank(mbusURLString) {
+		errs = append(errs, bosherr.Error("cloud_provider.mbus must be provided"))
+	}
+
+	agentProperties, found := manifest.Properties["agent"]
+	if !found {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent must be specified"))
+	}
+
+	if len(errs) > 0 {
+		return bosherr.NewMultiError(errs...)
+	}
+
+	agentPropertiesMap, ok := agentProperties.(biproperty.Map)
+	if !ok {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent must be a hash"))
+		return bosherr.NewMultiError(errs...)
+	}
+
+	agentMbusURLProperty, found := agentPropertiesMap["mbus"]
+	if !found {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus must be specified"))
+		return bosherr.NewMultiError(errs...)
+	}
+
+	agentMbusURLString, ok := agentMbusURLProperty.(string)
+	if !ok {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus should be string"))
+		return bosherr.NewMultiError(errs...)
+	}
+
+	mbusURL, err := url.ParseRequestURI(mbusURLString)
+	if err != nil {
+		errs = append(errs, bosherr.Error("cloud_provider.mbus should be a valid URL"))
+	}
+
+	agentMbusURL, err := url.ParseRequestURI(agentMbusURLString)
+	if err != nil {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus should be a valid URL"))
+	}
+
+	if len(errs) > 0 {
+		return bosherr.NewMultiError(errs...)
+	}
+
+	if mbusURL.Scheme != "https" {
+		errs = append(errs, bosherr.Error("cloud_provider.mbus must use https protocol"))
+	}
+
+	if agentMbusURL.Scheme != "https" {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus must use https protocol"))
+	}
+
+	if (mbusURL.User != nil) && (agentMbusURL.User != nil) {
+		mbusCredsAreEqual := (agentMbusURL.User.String() == mbusURL.User.String())
+		if !mbusCredsAreEqual {
+			errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same password and username"))
+		}
+	}
+
+	_, mbusPort, _ := net.SplitHostPort(mbusURL.Host)
+	_, agentMbusPort, _ := net.SplitHostPort(agentMbusURL.Host)
+	if mbusPort != agentMbusPort {
+		errs = append(errs, bosherr.Error("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same ports"))
+	}
+
+	if len(errs) > 0 {
+		return bosherr.NewMultiError(errs...)
+	}
+
+	return nil
+
 }

--- a/installation/manifest/validator_test.go
+++ b/installation/manifest/validator_test.go
@@ -124,8 +124,9 @@ var _ = Describe("Validator", func() {
 			Expect(err.Error()).To(ContainSubstring("cloud_provider.properties.agent must be specified"))
 		})
 
-		It("validates agent mbus property is empty", func() {
+		It("validates agent mbus property is not empty", func() {
 			manifest := Manifest{
+				Mbus:       "some-url",
 				Properties: biproperty.Map{"agent": biproperty.Map{}},
 			}
 

--- a/installation/manifest/validator_test.go
+++ b/installation/manifest/validator_test.go
@@ -30,11 +30,15 @@ var _ = Describe("Validator", func() {
 
 		validManifest = Manifest{
 			Name: "fake-installation-name",
+			Mbus: "https://user:pass@ip-address:4222",
 			Template: ReleaseJobRef{
 				Name:    "cpi",
 				Release: "provided-valid-release-name",
 			},
 			Properties: biproperty.Map{
+				"agent": biproperty.Map{
+					"mbus": "https://user:pass@0.0.0.0:4222",
+				},
 				"fake-prop-key": "fake-prop-value",
 				"fake-prop-map-key": biproperty.Map{
 					"fake-prop-key": "fake-prop-value",
@@ -101,5 +105,81 @@ var _ = Describe("Validator", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("cloud_provider.template.release 'not-provided-valid-release-name' must refer to a release in releases"))
 		})
+
+		It("validates mbus is not blank", func() {
+			manifest := Manifest{Mbus: ""}
+
+			err := validator.Validate(manifest, releaseSetManifest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.mbus must be provided"))
+		})
+
+		It("validates agent properties are not specified", func() {
+			manifest := Manifest{
+				Properties: biproperty.Map{},
+			}
+
+			err := validator.Validate(manifest, releaseSetManifest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.properties.agent must be specified"))
+		})
+
+		It("validates agent mbus property is empty", func() {
+			manifest := Manifest{
+				Properties: biproperty.Map{"agent": biproperty.Map{}},
+			}
+
+			err := validator.Validate(manifest, releaseSetManifest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.properties.agent.mbus must be specified"))
+		})
+
+		It("validates mbus and agnet mbus are valid URLs", func() {
+			manifest := Manifest{
+				Mbus: "invalid-url",
+				Properties: biproperty.Map{
+					"agent": biproperty.Map{
+						"mbus": "invalid-url",
+					},
+				},
+			}
+
+			err := validator.Validate(manifest, releaseSetManifest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.mbus should be a valid URL"))
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.properties.agent.mbus should be a valid URL"))
+		})
+
+		It("validates mbus and agent mbus URLs use https protocol", func() {
+			manifest := Manifest{
+				Mbus: "http://valid-url",
+				Properties: biproperty.Map{
+					"agent": biproperty.Map{
+						"mbus": "http://valid-url",
+					},
+				},
+			}
+
+			err := validator.Validate(manifest, releaseSetManifest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.mbus must use https protocol"))
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.properties.agent.mbus must use https protocol"))
+		})
+
+		It("validates mbus and agent mbus URLs use https protocol", func() {
+			manifest := Manifest{
+				Mbus: "https://valid-url:3000",
+				Properties: biproperty.Map{
+					"agent": biproperty.Map{
+						"mbus": "https://valid-url:3001",
+					},
+				},
+			}
+
+			err := validator.Validate(manifest, releaseSetManifest)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cloud_provider.properties.agent.mbus and cloud_provider.mbus should have the same ports"))
+		})
+
 	})
 })


### PR DESCRIPTION
Hey, all.

This PR add validations to prevent two a common errors that are not so easy to debug for a newcomer. 

The first problem is that [bosh-agent does not expect having http](https://github.com/cloudfoundry/bosh-agent/blob/e726cc12a3ca0d875a3c7bbf42414365a67aa7f6/mbus/handler_provider.go#L50) as mbus protocol, so it simply skips connecting to mbus. This means that mbus properties should always have https protocol.

The second error is typos in passwords/usernames/ports of mbus parameters. This PR adds checks if this properties are similar in mbus URLs in  `cloud_properties.mbus` and `cloud_properties.properties.agent.mbus`.

What do you think on this changes?