### PR TITLE
Support BOSH_DEPLOYMENT, BOSH_ENVIRONMENT

### DIFF
--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -24,7 +24,7 @@ type BoshOpts struct {
 	UAAClientOpt       string `long:"uaa-client"        description:"Override UAA client"        env:"BOSH_CLIENT"`
 	UAAClientSecretOpt string `long:"uaa-client-secret" description:"Override UAA client secret" env:"BOSH_CLIENT_SECRET"`
 
-	DeploymentOpt string `long:"deployment" short:"d" description:"Deployment name"`
+	DeploymentOpt string `long:"deployment" short:"d" description:"Deployment name" env:"BOSH_DEPLOYMENT"`
 
 	// Output formatting
 	JSONOpt           bool `long:"json"                      description:"Output as JSON"`

--- a/cmd/opts_test.go
+++ b/cmd/opts_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Opts", func() {
 			Describe("DeploymentOpt", func() {
 				It("contains desired values", func() {
 					Expect(getStructTagForName("DeploymentOpt", opts)).To(Equal(
-						`long:"deployment" short:"d" description:"Deployment name"`,
+						`long:"deployment" short:"d" description:"Deployment name" env:"BOSH_DEPLOYMENT"`,
 					))
 				})
 			})


### PR DESCRIPTION
Generically, for things like `.envrc`...

    $ cd workspace/cf-release
    direnv: loading .envrc
    direnv: export +BOSH_DEPLOYMENT +BOSH_ENVIRONMENT

    $ cat .envrc
    export BOSH_ENVIRONMENT="$(hostname)"
    export BOSH_DEPLOYMENT="$(basename "$PWD")"

    $ bosh ssh mysql
    Using environment 'https://lake:25555' as user 'admin'
    
    Using deployment 'cf-release'
    ...

What do you think?