### PR TITLE
Switch `bosh instances` to the /instances endpoint

### DIFF
--- a/cmd/instance_table.go
+++ b/cmd/instance_table.go
@@ -12,10 +12,11 @@ type InstanceTableValues struct {
 	Name    boshtbl.Value
 	Process boshtbl.Value
 
-	State  boshtbl.Value
-	AZ     boshtbl.Value
-	VMType boshtbl.Value
-	IPs    boshtbl.Value
+	ProcessState boshtbl.Value
+	State        boshtbl.Value
+	AZ           boshtbl.Value
+	VMType       boshtbl.Value
+	IPs          boshtbl.Value
 
 	// Details
 	VMCID        boshtbl.Value
@@ -47,12 +48,13 @@ var InstanceTableHeader = InstanceTableValues{
 	Name:    boshtbl.NewValueString("Instance"),
 	Process: boshtbl.NewValueString("Process"),
 
-	State:  boshtbl.NewValueString("State"),
-	AZ:     boshtbl.NewValueString("AZ"),
-	VMType: boshtbl.NewValueString("VM Type"),
-	IPs:    boshtbl.NewValueString("IPs"),
+	ProcessState: boshtbl.NewValueString("Process State"),
+	AZ:           boshtbl.NewValueString("AZ"),
+	VMType:       boshtbl.NewValueString("VM Type"),
+	IPs:          boshtbl.NewValueString("IPs"),
 
 	// Details
+	State:        boshtbl.NewValueString("State"),
 	VMCID:        boshtbl.NewValueString("VM CID"),
 	DiskCID:      boshtbl.NewValueString("Disk CID"),
 	AgentID:      boshtbl.NewValueString("Agent ID"),
@@ -91,8 +93,8 @@ func (t InstanceTable) ForVMInfo(i boshdir.VMInfo) InstanceTableValues {
 		Name:    t.buildName(i),
 		Process: boshtbl.ValueString{},
 
-		State: boshtbl.ValueFmt{
-			V:     boshtbl.NewValueString(i.State),
+		ProcessState: boshtbl.ValueFmt{
+			V:     boshtbl.NewValueString(i.ProcessState),
 			Error: !i.IsRunning(),
 		},
 
@@ -101,6 +103,10 @@ func (t InstanceTable) ForVMInfo(i boshdir.VMInfo) InstanceTableValues {
 		IPs:    boshtbl.NewValueStrings(i.IPs),
 
 		// Details
+		State: boshtbl.ValueFmt{
+			V:     boshtbl.NewValueString(i.State),
+			Error: !i.IsRunning(),
+		},
 		VMCID:        boshtbl.NewValueString(i.VMID),
 		DiskCID:      boshtbl.NewValueString(i.DiskID),
 		AgentID:      boshtbl.NewValueString(i.AgentID),
@@ -170,7 +176,7 @@ func (t InstanceTable) ForProcess(p boshdir.VMInfoProcess) InstanceTableValues {
 		Name:    boshtbl.ValueString{},
 		Process: boshtbl.NewValueString(p.Name),
 
-		State: boshtbl.ValueFmt{
+		ProcessState: boshtbl.ValueFmt{
 			V:     boshtbl.NewValueString(p.State),
 			Error: !p.IsRunning(),
 		},
@@ -190,10 +196,10 @@ func (t InstanceTable) AsValues(v InstanceTableValues) []boshtbl.Value {
 		result = append(result, v.Process)
 	}
 
-	result = append(result, []boshtbl.Value{v.State, v.AZ, v.IPs}...)
+	result = append(result, []boshtbl.Value{v.ProcessState, v.AZ, v.IPs}...)
 
 	if t.Details {
-		result = append(result, []boshtbl.Value{v.VMCID, v.VMType, v.DiskCID, v.AgentID, v.Resurrection}...)
+		result = append(result, []boshtbl.Value{v.State, v.VMCID, v.VMType, v.DiskCID, v.AgentID, v.Resurrection}...)
 	} else if t.VMDetails {
 		result = append(result, []boshtbl.Value{v.VMCID, v.VMType}...)
 	}

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -29,7 +29,7 @@ func (c InstancesCmd) Run(opts InstancesOpts) error {
 	}
 
 	table := boshtbl.Table{
-		Content: "vms",
+		Content: "instances",
 
 		HeaderVals: instTable.AsValues(instTable.Header()),
 

--- a/cmd/instances.go
+++ b/cmd/instances.go
@@ -16,7 +16,7 @@ func NewInstancesCmd(ui boshui.UI, deployment boshdir.Deployment) InstancesCmd {
 }
 
 func (c InstancesCmd) Run(opts InstancesOpts) error {
-	vmInfos, err := c.deployment.VMInfos()
+	instanceInfos, err := c.deployment.InstanceInfos()
 	if err != nil {
 		return err
 	}
@@ -41,7 +41,7 @@ func (c InstancesCmd) Run(opts InstancesOpts) error {
 		Notes: []string{"(*) Bootstrap node"},
 	}
 
-	for _, info := range vmInfos {
+	for _, info := range instanceInfos {
 		if opts.Failing && info.IsRunning() {
 			continue
 		}

--- a/cmd/instances_test.go
+++ b/cmd/instances_test.go
@@ -37,7 +37,7 @@ var _ = Describe("InstancesCmd", func() {
 
 		act := func() error { return command.Run(opts) }
 
-		Context("when VMs are successfully retrieved", func() {
+		Context("when instances are successfully retrieved", func() {
 			var (
 				infos          []boshdir.VMInfo
 				procCPUTotal   float64
@@ -59,12 +59,13 @@ var _ = Describe("InstancesCmd", func() {
 					{
 						JobName:      "job-name",
 						Index:        &index1,
-						State:        "in1-state",
+						ProcessState: "in1-process-state",
 						ResourcePool: "in1-rp",
 
 						IPs: []string{"in1-ip1", "in1-ip2"},
 						DNS: []string{"in1-dns1", "in1-dns2"},
 
+						State:              "in1-state",
 						VMID:               "in1-cid",
 						AgentID:            "in1-agent-id",
 						ResurrectionPaused: false,
@@ -108,13 +109,14 @@ var _ = Describe("InstancesCmd", func() {
 					{
 						JobName:      "job-name",
 						Index:        &index2,
-						State:        "in2-state",
+						ProcessState: "in2-process-state",
 						AZ:           "in2-az",
 						ResourcePool: "in2-rp",
 
 						IPs: []string{"in2-ip1"},
 						DNS: []string{"in2-dns1"},
 
+						State:              "in2-state",
 						VMID:               "in2-cid",
 						AgentID:            "in2-agent-id",
 						ResurrectionPaused: true,
@@ -143,7 +145,7 @@ var _ = Describe("InstancesCmd", func() {
 					{
 						JobName:      "",
 						Index:        nil,
-						State:        "unresponsive agent",
+						ProcessState: "unresponsive agent",
 						ResourcePool: "",
 					},
 				}
@@ -151,15 +153,15 @@ var _ = Describe("InstancesCmd", func() {
 				deployment.VMInfosReturns(infos, nil)
 			})
 
-			It("lists VMs for the deployment", func() {
+			It("lists instances for the deployment", func() {
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 					},
@@ -175,7 +177,7 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/1"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
 								},
@@ -186,7 +188,7 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/2"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
 									boshtbl.NewValueString("in2-az"),
 									boshtbl.NewValueStrings([]string{"in2-ip1"}),
 								},
@@ -209,18 +211,18 @@ var _ = Describe("InstancesCmd", func() {
 				}))
 			})
 
-			It("lists VMs with processes", func() {
+			It("lists instances with processes", func() {
 				opts.Processes = true
 
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
 						boshtbl.NewValueString("Process"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 					},
@@ -237,7 +239,7 @@ var _ = Describe("InstancesCmd", func() {
 								{
 									boshtbl.NewValueString("job-name/1"),
 									boshtbl.ValueString{},
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
 								},
@@ -263,7 +265,7 @@ var _ = Describe("InstancesCmd", func() {
 								{
 									boshtbl.NewValueString("job-name/2"),
 									boshtbl.ValueString{},
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
 									boshtbl.NewValueString("in2-az"),
 									boshtbl.NewValueStrings([]string{"in2-ip1"}),
 								},
@@ -294,19 +296,20 @@ var _ = Describe("InstancesCmd", func() {
 				}))
 			})
 
-			It("lists VMs for the deployment including details", func() {
+			It("lists instances for the deployment including details", func() {
 				opts.Details = true
 
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
+						boshtbl.NewValueString("State"),
 						boshtbl.NewValueString("VM CID"),
 						boshtbl.NewValueString("VM Type"),
 						boshtbl.NewValueString("Disk CID"),
@@ -325,9 +328,10 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/1"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
 									boshtbl.NewValueString("in1-cid"),
 									boshtbl.NewValueString("in1-rp"),
 									boshtbl.ValueString{},
@@ -341,9 +345,10 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/2"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
 									boshtbl.NewValueString("in2-az"),
 									boshtbl.NewValueStrings([]string{"in2-ip1"}),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
 									boshtbl.NewValueString("in2-cid"),
 									boshtbl.NewValueString("in2-rp"),
 									boshtbl.ValueString{},
@@ -360,6 +365,7 @@ var _ = Describe("InstancesCmd", func() {
 									boshtbl.NewValueFmt(boshtbl.NewValueString("unresponsive agent"), true),
 									boshtbl.ValueString{},
 									boshtbl.ValueStrings{},
+									boshtbl.NewValueFmt(boshtbl.NewValueString(""), true),
 									boshtbl.ValueString{},
 									boshtbl.ValueString{},
 									boshtbl.ValueString{},
@@ -374,17 +380,17 @@ var _ = Describe("InstancesCmd", func() {
 				}))
 			})
 
-			It("lists VMs for the deployment including dns", func() {
+			It("lists instances for the deployment including dns", func() {
 				opts.DNS = true
 
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 						boshtbl.NewValueString("DNS A Records"),
@@ -401,7 +407,7 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/1"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
 									boshtbl.NewValueStrings([]string{"in1-dns1", "in1-dns2"}),
@@ -413,7 +419,7 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/2"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
 									boshtbl.NewValueString("in2-az"),
 									boshtbl.NewValueStrings([]string{"in2-ip1"}),
 									boshtbl.NewValueStrings([]string{"in2-dns1"}),
@@ -438,19 +444,19 @@ var _ = Describe("InstancesCmd", func() {
 				}))
 			})
 
-			It("lists VMs for the deployment including vitals and processes", func() {
+			It("lists instances for the deployment including vitals and processes", func() {
 				opts.Vitals = true
 				opts.Processes = true
 
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
 						boshtbl.NewValueString("Process"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 						boshtbl.NewValueString("Uptime"),
@@ -478,7 +484,7 @@ var _ = Describe("InstancesCmd", func() {
 								{
 									boshtbl.NewValueString("job-name/1"),
 									boshtbl.ValueString{},
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
 									ValueUptime{},
@@ -537,7 +543,7 @@ var _ = Describe("InstancesCmd", func() {
 								{
 									boshtbl.NewValueString("job-name/2"),
 									boshtbl.ValueString{},
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in2-process-state"), true),
 									boshtbl.NewValueString("in2-az"),
 									boshtbl.NewValueStrings([]string{"in2-ip1"}),
 									ValueUptime{},
@@ -601,21 +607,21 @@ var _ = Describe("InstancesCmd", func() {
 				}))
 			})
 
-			It("lists failing (non-running) VMs", func() {
+			It("lists failing (non-running) instances", func() {
 				opts.Failing = true
 
 				// Hides second VM
-				infos[1].State = "running"
+				infos[1].ProcessState = "running"
 				infos[1].Processes[0].State = "running"
 
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 					},
@@ -631,7 +637,7 @@ var _ = Describe("InstancesCmd", func() {
 							Rows: [][]boshtbl.Value{
 								{
 									boshtbl.NewValueString("job-name/1"),
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
 								},
@@ -654,7 +660,7 @@ var _ = Describe("InstancesCmd", func() {
 				}))
 			})
 
-			It("includes failing processes when listing failing (non-running) VMs and processes", func() {
+			It("includes failing processes when listing failing (non-running) instances and processes", func() {
 				opts.Failing = true
 				opts.Processes = true
 
@@ -662,18 +668,18 @@ var _ = Describe("InstancesCmd", func() {
 				infos[0].Processes[0].State = "running"
 
 				// Hides second VM completely
-				infos[1].State = "running"
+				infos[1].ProcessState = "running"
 				infos[1].Processes[0].State = "running"
 
 				Expect(act()).ToNot(HaveOccurred())
 
 				Expect(ui.Table).To(Equal(boshtbl.Table{
-					Content: "vms",
+					Content: "instances",
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
 						boshtbl.NewValueString("Process"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 					},
@@ -690,7 +696,7 @@ var _ = Describe("InstancesCmd", func() {
 								{
 									boshtbl.NewValueString("job-name/1"),
 									boshtbl.ValueString{},
-									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
+									boshtbl.NewValueFmt(boshtbl.NewValueString("in1-process-state"), true),
 									boshtbl.ValueString{},
 									boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
 								},
@@ -722,7 +728,7 @@ var _ = Describe("InstancesCmd", func() {
 			})
 		})
 
-		It("returns error if VMs cannot be retrieved", func() {
+		It("returns error if instances cannot be retrieved", func() {
 			deployment.VMInfosReturns(nil, errors.New("fake-err"))
 
 			err := act()

--- a/cmd/vms_test.go
+++ b/cmd/vms_test.go
@@ -50,7 +50,7 @@ var _ = Describe("VMsCmd", func() {
 					{
 						JobName:      "job-name",
 						Index:        &index1,
-						State:        "in1-state",
+						ProcessState: "in1-state",
 						ResourcePool: "in1-rp",
 
 						IPs: []string{"in1-ip1", "in1-ip2"},
@@ -77,7 +77,7 @@ var _ = Describe("VMsCmd", func() {
 					{
 						JobName:      "job-name",
 						Index:        &index2,
-						State:        "in2-state",
+						ProcessState: "in2-state",
 						AZ:           "in2-az",
 						ResourcePool: "in2-rp",
 
@@ -105,7 +105,7 @@ var _ = Describe("VMsCmd", func() {
 					{
 						JobName:      "",
 						Index:        nil,
-						State:        "unresponsive agent",
+						ProcessState: "unresponsive agent",
 						ResourcePool: "",
 					},
 				}
@@ -130,7 +130,7 @@ var _ = Describe("VMsCmd", func() {
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 						boshtbl.NewValueString("VM CID"),
@@ -182,9 +182,10 @@ var _ = Describe("VMsCmd", func() {
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
+						boshtbl.NewValueString("State"),
 						boshtbl.NewValueString("VM CID"),
 						boshtbl.NewValueString("VM Type"),
 						boshtbl.NewValueString("Disk CID"),
@@ -200,6 +201,7 @@ var _ = Describe("VMsCmd", func() {
 							boshtbl.NewValueFmt(boshtbl.NewValueString("in1-state"), true),
 							boshtbl.ValueString{},
 							boshtbl.NewValueStrings([]string{"in1-ip1", "in1-ip2"}),
+							boshtbl.NewValueFmt(boshtbl.NewValueString(""), true),
 							boshtbl.NewValueString("in1-cid"),
 							boshtbl.NewValueString("in1-rp"),
 							boshtbl.ValueString{},
@@ -211,6 +213,7 @@ var _ = Describe("VMsCmd", func() {
 							boshtbl.NewValueFmt(boshtbl.NewValueString("in2-state"), true),
 							boshtbl.NewValueString("in2-az"),
 							boshtbl.NewValueStrings([]string{"in2-ip1"}),
+							boshtbl.NewValueFmt(boshtbl.NewValueString(""), true),
 							boshtbl.NewValueString("in2-cid"),
 							boshtbl.NewValueString("in2-rp"),
 							boshtbl.ValueString{},
@@ -222,6 +225,7 @@ var _ = Describe("VMsCmd", func() {
 							boshtbl.NewValueFmt(boshtbl.NewValueString("unresponsive agent"), true),
 							boshtbl.ValueString{},
 							boshtbl.ValueStrings{},
+							boshtbl.NewValueFmt(boshtbl.NewValueString(""), true),
 							boshtbl.ValueString{},
 							boshtbl.ValueString{},
 							boshtbl.ValueString{},
@@ -246,7 +250,7 @@ var _ = Describe("VMsCmd", func() {
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 						boshtbl.NewValueString("VM CID"),
@@ -302,7 +306,7 @@ var _ = Describe("VMsCmd", func() {
 
 					HeaderVals: []boshtbl.Value{
 						boshtbl.NewValueString("Instance"),
-						boshtbl.NewValueString("State"),
+						boshtbl.NewValueString("Process State"),
 						boshtbl.NewValueString("AZ"),
 						boshtbl.NewValueString("IPs"),
 						boshtbl.NewValueString("VM CID"),

--- a/director/fakes/fake_deployment.go
+++ b/director/fakes/fake_deployment.go
@@ -437,6 +437,10 @@ func (fake *FakeDeployment) VMInfos() ([]director.VMInfo, error) {
 	}
 }
 
+func (fake *FakeDeployment) InstanceInfos() ([]director.VMInfo, error) {
+	return fake.VMInfos()
+}
+
 func (fake *FakeDeployment) VMInfosCallCount() int {
 	fake.vMInfosMutex.RLock()
 	defer fake.vMInfosMutex.RUnlock()

--- a/director/instances.go
+++ b/director/instances.go
@@ -1,0 +1,25 @@
+package director
+
+import (
+	"strings"
+)
+
+func (d DeploymentImpl) InstanceInfos() ([]VMInfo, error) {
+	infos, err := d.client.DeploymentInstanceInfos(d.name)
+
+	if err != nil && strings.Contains(err.Error(), "404") {
+		infos, err = d.client.DeploymentVMInfos(d.name)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	addTimestampToInfos(infos)
+
+	return infos, nil
+}
+
+func (c Client) DeploymentInstanceInfos(deploymentName string) ([]VMInfo, error) {
+	return c.DeploymentResourceInfos(deploymentName, "instances")
+}

--- a/director/instances.go
+++ b/director/instances.go
@@ -1,25 +1,14 @@
 package director
 
-import (
-	"strings"
-)
-
 func (d DeploymentImpl) InstanceInfos() ([]VMInfo, error) {
 	infos, err := d.client.DeploymentInstanceInfos(d.name)
-
-	if err != nil && strings.Contains(err.Error(), "404") {
-		infos, err = d.client.DeploymentVMInfos(d.name)
-	}
-
 	if err != nil {
 		return nil, err
 	}
-
-	addTimestampToInfos(infos)
 
 	return infos, nil
 }
 
 func (c Client) DeploymentInstanceInfos(deploymentName string) ([]VMInfo, error) {
-	return c.DeploymentResourceInfos(deploymentName, "instances")
+	return c.deploymentResourceInfos(deploymentName, "instances")
 }

--- a/director/interfaces.go
+++ b/director/interfaces.go
@@ -92,6 +92,7 @@ type Deployment interface {
 
 	Stemcells() ([]Stemcell, error)
 	VMInfos() ([]VMInfo, error)
+	InstanceInfos() ([]VMInfo, error)
 
 	Errands() ([]Errand, error)
 	RunErrand(string, bool) (ErrandResult, error)

--- a/director/vms.go
+++ b/director/vms.go
@@ -14,16 +14,17 @@ type VMInfo struct {
 
 	Timestamp time.Time
 
-	JobName   string `json:"job_name"`
-	ID        string `json:"id"`
-	Index     *int   `json:"index"`
-	State     string `json:"job_state"` // e.g. "running"
-	Bootstrap bool
+	JobName      string `json:"job_name"`
+	ID           string `json:"id"`
+	Index        *int   `json:"index"`
+	ProcessState string `json:"job_state"` // e.g. "running"
+	Bootstrap    bool
 
 	IPs []string `json:"ips"`
 	DNS []string `json:"dns"`
 
 	AZ           string `json:"az"`
+	State        string `json:"state"`
 	VMID         string `json:"vm_cid"`
 	VMType       string `json:"vm_type"`
 	ResourcePool string `json:"resource_pool"`
@@ -86,7 +87,7 @@ type VMInfoVitalsUptime struct {
 }
 
 func (i VMInfo) IsRunning() bool {
-	if i.State != "running" {
+	if i.ProcessState != "running" {
 		return false
 	}
 

--- a/director/vms.go
+++ b/director/vms.go
@@ -110,26 +110,35 @@ func (d DeploymentImpl) VMInfos() ([]VMInfo, error) {
 		return nil, err
 	}
 
+	addTimestampToInfos(infos)
+
+	return infos, nil
+}
+
+func addTimestampToInfos(infos []VMInfo) {
 	t := time.Now()
 
 	for _, info := range infos {
 		info.Timestamp = t
 	}
-
-	return infos, nil
 }
 
 func (c Client) DeploymentVMInfos(deploymentName string) ([]VMInfo, error) {
+	return c.DeploymentResourceInfos(deploymentName, "vms")
+}
+
+func (c Client) DeploymentResourceInfos(deploymentName string, resourceType string) ([]VMInfo, error) {
 	if len(deploymentName) == 0 {
 		return nil, bosherr.Error("Expected non-empty deployment name")
 	}
 
-	path := fmt.Sprintf("/deployments/%s/vms?format=full", deploymentName)
+	path := fmt.Sprintf("/deployments/%s/%s?format=full", deploymentName, resourceType)
 
 	_, resultBytes, err := c.taskClientRequest.GetResult(path)
+
 	if err != nil {
 		return nil, bosherr.WrapErrorf(
-			err, "Listing deployment '%s' VMs infos", deploymentName)
+			err, "Listing deployment '%s' %s infos", deploymentName, resourceType)
 	}
 
 	var resps []VMInfo
@@ -144,7 +153,7 @@ func (c Client) DeploymentVMInfos(deploymentName string) ([]VMInfo, error) {
 		err := json.Unmarshal([]byte(piece), &resp)
 		if err != nil {
 			return nil, bosherr.WrapErrorf(
-				err, "Unmarshaling VM info response: '%s'", string(piece))
+				err, "Unmarshaling %s info response: '%s'", strings.TrimSuffix(resourceType, "s"), string(piece))
 		}
 
 		resps = append(resps, resp)

--- a/director/vms.go
+++ b/director/vms.go
@@ -4,15 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
 type VMInfo struct {
 	AgentID string `json:"agent_id"`
-
-	Timestamp time.Time
 
 	JobName      string `json:"job_name"`
 	ID           string `json:"id"`
@@ -110,24 +107,14 @@ func (d DeploymentImpl) VMInfos() ([]VMInfo, error) {
 		return nil, err
 	}
 
-	addTimestampToInfos(infos)
-
 	return infos, nil
 }
 
-func addTimestampToInfos(infos []VMInfo) {
-	t := time.Now()
-
-	for _, info := range infos {
-		info.Timestamp = t
-	}
-}
-
 func (c Client) DeploymentVMInfos(deploymentName string) ([]VMInfo, error) {
-	return c.DeploymentResourceInfos(deploymentName, "vms")
+	return c.deploymentResourceInfos(deploymentName, "vms")
 }
 
-func (c Client) DeploymentResourceInfos(deploymentName string, resourceType string) ([]VMInfo, error) {
+func (c Client) deploymentResourceInfos(deploymentName string, resourceType string) ([]VMInfo, error) {
 	if len(deploymentName) == 0 {
 		return nil, bosherr.Error("Expected non-empty deployment name")
 	}
@@ -135,7 +122,6 @@ func (c Client) DeploymentResourceInfos(deploymentName string, resourceType stri
 	path := fmt.Sprintf("/deployments/%s/%s?format=full", deploymentName, resourceType)
 
 	_, resultBytes, err := c.taskClientRequest.GetResult(path)
-
 	if err != nil {
 		return nil, bosherr.WrapErrorf(
 			err, "Listing deployment '%s' %s infos", deploymentName, resourceType)

--- a/director/vms_test.go
+++ b/director/vms_test.go
@@ -2,7 +2,6 @@ package director_test
 
 import (
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,7 +31,6 @@ var _ = Describe("VMs", func() {
 	})
 
 	Describe("VMInfos", func() {
-
 		It("returns vm infos", func() {
 			ConfigureTaskResult(
 				ghttp.CombineHandlers(
@@ -89,8 +87,6 @@ var _ = Describe("VMs", func() {
 
 			Expect(infos[0]).To(Equal(VMInfo{
 				AgentID: "agent-id",
-
-				Timestamp: time.Time{},
 
 				JobName:      "job",
 				ID:           "id",

--- a/director/vms_test.go
+++ b/director/vms_test.go
@@ -91,11 +91,11 @@ var _ = Describe("VMs", func() {
 
 				Timestamp: time.Time{},
 
-				JobName:   "job",
-				ID:        "id",
-				Index:     &index,
-				State:     "running",
-				Bootstrap: true,
+				JobName:      "job",
+				ID:           "id",
+				Index:        &index,
+				ProcessState: "running",
+				Bootstrap:    true,
 
 				IPs: []string{"ip"},
 				DNS: []string{"dns"},


### PR DESCRIPTION
The instances command of the go cli does now call /instances instead of /vms.
If the director does not support /instances (< v256) we fall back to /vms.

Additionally we renamed `State` to `Process State` and added a `State` column to the instances output which reflect the instance state. All according to @cppforlife feedback in https://www.pivotaltracker.com/story/show/114101171
