### PR TITLE
Show blob name when downloading

### DIFF
--- a/releasedir/index/fs_index.go
+++ b/releasedir/index/fs_index.go
@@ -94,7 +94,8 @@ func (i FSIndex) Find(name, fingerprint string) (string, string, error) {
 
 	for _, entry := range entries {
 		if entry.Version == fingerprint {
-			blobPath, err := i.blobs.Get(entry.BlobstoreID, entry.SHA1)
+			blobName := fmt.Sprintf("%s/%s", name, entry.Version)
+			blobPath, err := i.blobs.Get(blobName, entry.BlobstoreID, entry.SHA1)
 			if err != nil {
 				return "", "", err
 			}

--- a/releasedir/index/fs_index_blobs.go
+++ b/releasedir/index/fs_index_blobs.go
@@ -39,7 +39,7 @@ func NewFSIndexBlobs(
 }
 
 // Get gurantees that returned file matches requested SHA1.
-func (c FSIndexBlobs) Get(blobID, sha1 string) (string, error) {
+func (c FSIndexBlobs) Get(name string, blobID string, sha1 string) (string, error) {
 	dstPath, err := c.blobPath(sha1)
 	if err != nil {
 		return "", err
@@ -60,24 +60,24 @@ func (c FSIndexBlobs) Get(blobID, sha1 string) (string, error) {
 	}
 
 	if c.blobstore != nil && len(blobID) > 0 {
-		desc := fmt.Sprintf("%s (sha1=%s)", blobID, sha1)
+		desc := fmt.Sprintf("sha1=%s", sha1)
 
-		c.reporter.IndexEntryDownloadStarted("", desc)
+		c.reporter.IndexEntryDownloadStarted(name, desc)
 
 		// SHA1 expected to be checked via blobstore
 		path, err := c.blobstore.Get(blobID, sha1)
 		if err != nil {
-			c.reporter.IndexEntryDownloadFinished("", desc, err)
+			c.reporter.IndexEntryDownloadFinished(name, desc, err)
 			return "", bosherr.WrapErrorf(err, "Downloading blob '%s' with SHA1 '%s'", blobID, sha1)
 		}
 
 		err = c.fs.Rename(path, dstPath)
 		if err != nil {
-			c.reporter.IndexEntryDownloadFinished("", desc, err)
+			c.reporter.IndexEntryDownloadFinished(name, desc, err)
 			return "", bosherr.WrapErrorf(err, "Moving blob '%s' into cache", blobID)
 		}
 
-		c.reporter.IndexEntryDownloadFinished("", desc, nil)
+		c.reporter.IndexEntryDownloadFinished(name, desc, nil)
 
 		return dstPath, nil
 	}

--- a/releasedir/index/fs_index_blobs_test.go
+++ b/releasedir/index/fs_index_blobs_test.go
@@ -42,7 +42,7 @@ var _ = Describe("FSIndexBlobs", func() {
 				It("returns path to a downloaded blob if it already exists", func() {
 					fs.WriteFileString("/dir/sub-dir/sha1", "file")
 
-					path, err := blobs.Get("blob-id", "sha1")
+					path, err := blobs.Get("name", "blob-id", "sha1")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(path).To(Equal("/dir/sub-dir/sha1"))
 				})
@@ -53,7 +53,7 @@ var _ = Describe("FSIndexBlobs", func() {
 					})
 					fs.WriteFileString("/dir/sub-dir/sha1", "file")
 
-					_, err := blobs.Get("blob-id", "sha1")
+					_, err := blobs.Get("name", "blob-id", "sha1")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring(
 						"Expected local copy ('/dir/sub-dir/sha1') of blob 'blob-id' to have SHA1 'sha1' but was 'wrong-sha1'"))
@@ -65,7 +65,7 @@ var _ = Describe("FSIndexBlobs", func() {
 					})
 					fs.WriteFileString("/dir/sub-dir/sha1", "file")
 
-					_, err := blobs.Get("blob-id", "sha1")
+					_, err := blobs.Get("name", "blob-id", "sha1")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("fake-err"))
 				})
@@ -74,7 +74,7 @@ var _ = Describe("FSIndexBlobs", func() {
 					fs.ExpandPathExpanded = "/full-dir"
 					fs.WriteFileString("/full-dir/sha1", "file")
 
-					path, err := blobs.Get("blob-id", "sha1")
+					path, err := blobs.Get("name", "blob-id", "sha1")
 					Expect(err).ToNot(HaveOccurred())
 					Expect(path).To(Equal("/full-dir/sha1"))
 
@@ -84,7 +84,7 @@ var _ = Describe("FSIndexBlobs", func() {
 				It("returns error if expanding directory path fails", func() {
 					fs.ExpandPathErr = errors.New("fake-err")
 
-					_, err := blobs.Get("blob-id", "sha1")
+					_, err := blobs.Get("name", "blob-id", "sha1")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("fake-err"))
 				})
@@ -92,7 +92,7 @@ var _ = Describe("FSIndexBlobs", func() {
 				It("returns error if creating directory fails", func() {
 					fs.MkdirAllError = errors.New("fake-err")
 
-					_, err := blobs.Get("blob-id", "sha1")
+					_, err := blobs.Get("name", "blob-id", "sha1")
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("fake-err"))
 				})
@@ -107,7 +107,7 @@ var _ = Describe("FSIndexBlobs", func() {
 			itChecksIfFileIsAlreadyDownloaded()
 
 			It("returns error if downloaded blob does not exist", func() {
-				_, err := blobs.Get("blob-id", "sha1")
+				_, err := blobs.Get("name", "blob-id", "sha1")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Cannot find blob 'blob-id' with SHA1 'sha1'"))
 			})
@@ -125,7 +125,7 @@ var _ = Describe("FSIndexBlobs", func() {
 				blobstore.GetFileName = "/tmp/downloaded-path"
 				fs.WriteFileString("/tmp/downloaded-path", "blob")
 
-				path, err := blobs.Get("blob-id", "sha1")
+				path, err := blobs.Get("name", "blob-id", "sha1")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(path).To(Equal("/dir/sub-dir/sha1"))
 
@@ -136,19 +136,19 @@ var _ = Describe("FSIndexBlobs", func() {
 				Expect(reporter.IndexEntryDownloadFinishedCallCount()).To(Equal(1))
 
 				kind, desc := reporter.IndexEntryDownloadStartedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("blob-id (sha1=sha1)"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 
 				kind, desc, err = reporter.IndexEntryDownloadFinishedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("blob-id (sha1=sha1)"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 				Expect(err).To(BeNil())
 			})
 
 			It("returns error if downloading blob fails", func() {
 				blobstore.GetError = errors.New("fake-err")
 
-				_, err := blobs.Get("blob-id", "sha1")
+				_, err := blobs.Get("name", "blob-id", "sha1")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-err"))
 				Expect(err.Error()).To(ContainSubstring("Downloading blob 'blob-id'"))
@@ -157,19 +157,19 @@ var _ = Describe("FSIndexBlobs", func() {
 				Expect(reporter.IndexEntryDownloadFinishedCallCount()).To(Equal(1))
 
 				kind, desc := reporter.IndexEntryDownloadStartedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("blob-id (sha1=sha1)"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 
 				kind, desc, err = reporter.IndexEntryDownloadFinishedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("blob-id (sha1=sha1)"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 				Expect(err).ToNot(BeNil())
 			})
 
 			It("returns error if moving blob into cache fails", func() {
 				fs.RenameError = errors.New("fake-err")
 
-				_, err := blobs.Get("blob-id", "sha1")
+				_, err := blobs.Get("name", "blob-id", "sha1")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("fake-err"))
 				Expect(err.Error()).To(ContainSubstring("Moving blob 'blob-id'"))
@@ -178,12 +178,12 @@ var _ = Describe("FSIndexBlobs", func() {
 				Expect(reporter.IndexEntryDownloadFinishedCallCount()).To(Equal(1))
 
 				kind, desc := reporter.IndexEntryDownloadStartedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("blob-id (sha1=sha1)"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 
 				kind, desc, err = reporter.IndexEntryDownloadFinishedArgsForCall(0)
-				Expect(kind).To(Equal(""))
-				Expect(desc).To(Equal("blob-id (sha1=sha1)"))
+				Expect(kind).To(Equal("name"))
+				Expect(desc).To(Equal("sha1=sha1"))
 				Expect(err).ToNot(BeNil())
 			})
 		})

--- a/releasedir/index/fs_index_test.go
+++ b/releasedir/index/fs_index_test.go
@@ -41,7 +41,8 @@ builds:
   fp: {version: fp, sha1: fp-sha1}
 format-version: "2"`)
 
-			blobs.GetStub = func(blobID, sha1 string) (string, error) {
+			blobs.GetStub = func(name string, blobID string, sha1 string) (string, error) {
+				Expect(name).To(Equal("name/fp"))
 				Expect(blobID).To(Equal(""))
 				Expect(sha1).To(Equal("fp-sha1"))
 				return "path", nil
@@ -77,7 +78,8 @@ builds:
   fp: {version: fp, sha1: fp-sha1, blobstore_id: fp-blob-id}
 format-version: "2"`)
 
-			blobs.GetStub = func(blobID, sha1 string) (string, error) {
+			blobs.GetStub = func(name string, blobID string, sha1 string) (string, error) {
+				Expect(name).To(Equal("name/fp"))
 				Expect(blobID).To(Equal("fp-blob-id"))
 				Expect(sha1).To(Equal("fp-sha1"))
 				return "path", nil

--- a/releasedir/index/interfaces.go
+++ b/releasedir/index/interfaces.go
@@ -10,7 +10,7 @@ type Index interface {
 //go:generate counterfeiter . IndexBlobs
 
 type IndexBlobs interface {
-	Get(blobID, sha1 string) (string, error)
+	Get(name string, blobID string, sha1 string) (string, error)
 	Add(path, sha1 string) (string, string, error)
 }
 


### PR DESCRIPTION
When downloading blobs, show `name/version` instead of an empty string. Also removes blob ID from the description since retaining it made the message extra long and it's more of an internal value.

Instead of...

    $ bosh create-release
	-- Started downloading '' (5716ff8a-baca-4471-8598-1e7c16842f02 (sha1=d110588a4eefc593509929f844df190d5281e8ff))
	-- Finished downloading '' (5716ff8a-baca-4471-8598-1e7c16842f02 (sha1=d110588a4eefc593509929f844df190d5281e8ff))
	-- Started downloading '' (31cce289-07cb-45bb-ab27-e5d03532117f (sha1=d35bd8d8b45098791b4668433bd9878678b59df8))
	-- Finished downloading '' (31cce289-07cb-45bb-ab27-e5d03532117f (sha1=d35bd8d8b45098791b4668433bd9878678b59df8))
	-- Started downloading '' (7cb7513b-f63f-49b1-8ade-3a9c9f9a86f9 (sha1=aa9d548cb6c4d9ad536da532987eabd3550f1ece))
	-- Finished downloading '' (7cb7513b-f63f-49b1-8ade-3a9c9f9a86f9 (sha1=aa9d548cb6c4d9ad536da532987eabd3550f1ece))

Show...

    $ bosh create-release
    -- Started downloading 'mysql/0687ba6d67528afdc81cfc8e46c1e31a33b8df7d' (sha1=d110588a4eefc593509929f844df190d5281e8ff)
    -- Finished downloading 'mysql/0687ba6d67528afdc81cfc8e46c1e31a33b8df7d' (sha1=d110588a4eefc593509929f844df190d5281e8ff)
    -- Started downloading 'legacy-build/ba156d253ad92a543027f02764abd343ced8e5a7' (sha1=d35bd8d8b45098791b4668433bd9878678b59df8)
    -- Finished downloading 'legacy-build/ba156d253ad92a543027f02764abd343ced8e5a7' (sha1=d35bd8d8b45098791b4668433bd9878678b59df8)
    -- Started downloading 'mc/1290a94a7934bab7c38b3e5d92527dc6219e0f89' (sha1=aa9d548cb6c4d9ad536da532987eabd3550f1ece)
    -- Finished downloading 'mc/1290a94a7934bab7c38b3e5d92527dc6219e0f89' (sha1=aa9d548cb6c4d9ad536da532987eabd3550f1ece)

Thoughts?