### PR TITLE
CPI job is called `warden_cpi` for quite some time

### DIFF
--- a/acceptance/assets/manifest.yml
+++ b/acceptance/assets/manifest.yml
@@ -32,7 +32,7 @@ networks:
 
 cloud_provider:
   template:
-    name: cpi
+    name: warden_cpi
     release: bosh-warden-cpi
   ssh_tunnel:
     host: 10.244.0.42


### PR DESCRIPTION
rename done in https://github.com/cppforlife/bosh-warden-cpi-release/commit/6a41873d696073d92c30e76a1727aa9ae5f4d684
pipeline fails since new releases of the warden-cpi are picked up due to
```
Command 'deploy' failed:
  Invalid CPI release 'bosh-warden-cpi':
    CPI release must contain specified job 'cpi'
```